### PR TITLE
fix build on 32-bit iOS

### DIFF
--- a/KittyMemory/KittyMemory.cpp
+++ b/KittyMemory/KittyMemory.cpp
@@ -598,7 +598,7 @@ namespace KittyScanner
         struct symtab_command *symtab_cmd = nullptr;
         struct nlist_64 *symtab = nullptr;
 #else
-        struct mach_header *header = (struct mach_header *)libInfo.header;
+        struct mach_header *header = (struct mach_header *)info.header;
         const int lc_seg = LC_SEGMENT;
         struct segment_command *curr_seg_cmd = nullptr;
         struct segment_command *linkedit_segment_cmd = nullptr;


### PR DESCRIPTION
I noticed that in the 32-bit Apple scope in the `KittyMemory` implementation file, the `info` object was (presumably) erroneously mislabeled as `libInfo`, which caused build errors (`"libInfo" not defined.`). After making this change, compilation for 32-bit iOS succeeds for me with no further problems and memory injection works perfectly.