### PR TITLE
Update KittyMemory.hpp

### DIFF
--- a/KittyMemory/KittyMemory.hpp
+++ b/KittyMemory/KittyMemory.hpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <vector>
+#include <unordered_map>
 
 #ifdef __ANDROID__
 #include <dlfcn.h>


### PR DESCRIPTION
prevent error: no template named 'unordered_map' in namespace 'std' in KittyScanner.hpp when build with android studio.

added :
#include <unordered_map>