### PR TITLE
Refactor writeData functions to handle address resolution and error checking

### DIFF
--- a/KittyMemory/writeData.hpp
+++ b/KittyMemory/writeData.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 
 #include "MemoryPatch.hpp"
+#include "KittyMemory.hpp"
 #include <libkern/_OSByteOrder.h>
 
 /*
@@ -17,7 +18,10 @@
  */
 static inline bool writeData8(const char *fileName, uintptr_t offset, uint8_t data)
 {
-    return MemoryPatch::createWithBytes(fileName, offset, &data, 1).Modify();
+    uintptr_t address = KittyMemory::getAbsoluteAddress(fileName, offset);
+    if (address == 0)
+        return false;
+    return MemoryPatch::createWithBytes(address, &data, 1).Modify();
 }
 
 static inline bool writeData8(uintptr_t address, uint8_t data)
@@ -30,8 +34,13 @@ static inline bool writeData8(uintptr_t address, uint8_t data)
  */
 static inline bool writeData16(const char *fileName, uintptr_t offset, uint16_t data)
 {
+    uintptr_t address = KittyMemory::getAbsoluteAddress(fileName, offset);
+    if (address == 0)
+        return false;
+
     uint16_t tmp_data = _OSSwapInt16(data);
-    return MemoryPatch::createWithBytes(fileName, offset, &tmp_data, 2).Modify();
+
+    return MemoryPatch::createWithBytes(address, &tmp_data, 2).Modify();
 }
 
 static inline bool writeData16(uintptr_t address, uint16_t data)
@@ -45,8 +54,12 @@ static inline bool writeData16(uintptr_t address, uint16_t data)
  */
 static inline bool writeData32(const char *fileName, uintptr_t offset, uint32_t data)
 {
+    uintptr_t address = KittyMemory::getAbsoluteAddress(fileName, offset);
+    if (address == 0)
+        return false;
     uint32_t tmp_data = _OSSwapInt32(data);
-    return MemoryPatch::createWithBytes(fileName, offset, &tmp_data, 4).Modify();
+
+    return MemoryPatch::createWithBytes(address, &tmp_data, 4).Modify();
 }
 
 static inline bool writeData32(uintptr_t address, uint32_t data)
@@ -60,8 +73,12 @@ static inline bool writeData32(uintptr_t address, uint32_t data)
  */
 static inline bool writeData64(const char *fileName, uintptr_t offset, uint64_t data)
 {
+    uintptr_t address = KittyMemory::getAbsoluteAddress(fileName, offset);
+    if (address == 0)
+        return false;
     uint64_t tmp_data = _OSSwapInt64(data);
-    return MemoryPatch::createWithBytes(fileName, offset, &tmp_data, 8).Modify();
+
+    return MemoryPatch::createWithBytes(address, &tmp_data, 8).Modify();
 }
 
 static inline bool writeData64(uintptr_t address, uint64_t data)


### PR DESCRIPTION
## Summary
- refactor writeData helpers in KittyMemory/writeData.hpp
- handle address resolution consistently before writing
- improve error checking around write operations

## Validation
- KittyMemory builds without compiler error for iOS using the example-ios as a test