### PR TITLE
fix(scanner): restore wildcard-leading IDA pattern matches

### DIFF
--- a/KittyMemory/KittyScanner.cpp
+++ b/KittyMemory/KittyScanner.cpp
@@ -29,18 +29,32 @@ namespace KittyScanner
         if (mask_len == 0 || start >= end || (end - start) < mask_len)
             return 0;
 
-        const uint8_t first_byte = pattern[0];
         const uint8_t *scan_start = reinterpret_cast<const uint8_t *>(start);
         const uint8_t *scan_end = reinterpret_cast<const uint8_t *>(end - mask_len);
 
-        for (const uint8_t *cur = scan_start; cur <= scan_end; ++cur)
+        // Anchor memchr on the first required byte in the mask.
+        // This preserves wildcard-leading IDA pattern semantics.
+        size_t anchor_index = 0;
+        while (anchor_index < mask_len && mask[anchor_index] != 'x')
+            ++anchor_index;
+
+        // All-wildcard mask matches at range start.
+        if (anchor_index == mask_len)
+            return start;
+
+        const uint8_t anchor_byte = pattern[anchor_index];
+        const uint8_t *anchor_scan_start = scan_start + anchor_index;
+        const uint8_t *anchor_scan_end = scan_end + anchor_index;
+
+        for (const uint8_t *cur = anchor_scan_start; cur <= anchor_scan_end; ++cur)
         {
-            cur = static_cast<const uint8_t *>(memchr(cur, first_byte, (scan_end - cur) + 1));
+            cur = static_cast<const uint8_t *>(memchr(cur, anchor_byte, (anchor_scan_end - cur) + 1));
             if (!cur)
                 break;
 
-            if (compare(cur, pattern, mask))
-                return reinterpret_cast<uintptr_t>(cur);
+            const uint8_t *candidate = cur - anchor_index;
+            if (compare(candidate, pattern, mask))
+                return reinterpret_cast<uintptr_t>(candidate);
         }
         return 0;
     }

--- a/example-android/example.cpp
+++ b/example-android/example.cpp
@@ -215,9 +215,14 @@ void test_thread()
     // scan with IDA pattern get one result
     found_at = KittyScanner::findIdaPatternFirst(search_start, search_end, "33 ? 55 66 ? 77 88 ? 99");
     KITTY_LOGI("found IDA pattern at: %p", (void *)found_at);
+    // scan with IDA pattern that starts with wildcards
+    found_at = KittyScanner::findIdaPatternFirst(search_start, search_end, "? ? 55 66 ? 77 88 ? 99");
+    KITTY_LOGI("found IDA leading-wildcard pattern at: %p", (void *)found_at);
     // scan with IDA pattern get all results
     found_at_list = KittyScanner::findIdaPatternAll(search_start, search_end, "33 ? 55 66 ? 77 88 ? 99");
     KITTY_LOGI("found IDA pattern results: %zu", found_at_list.size());
+    found_at_list = KittyScanner::findIdaPatternAll(search_start, search_end, "? ? 55 66 ? 77 88 ? 99");
+    KITTY_LOGI("found IDA leading-wildcard pattern results: %zu", found_at_list.size());
 
     // scan with data type & get one result
     uint32_t data = 0xdeadbeef;


### PR DESCRIPTION
Anchor fast-path search on the first required mask byte instead of pattern byte 0 to preserve leading-wildcard semantics.
Also add example-android coverage logs for leading-wildcard IDA pattern scans.

### Summary
This patch fixes a scanner regression where wildcard-leading IDA patterns can fail after the memchr-based optimization in `findInRange`.

### What Changed
1. Updated `KittyMemory/KittyScanner.cpp` in `findInRange(...)`:
   - Determine `anchor_index` as first required mask byte (`'x'`).
   - If all wildcards, return `start`.
   - Use `memchr` on `pattern[anchor_index]`.
   - Reconstruct candidate start (`cur - anchor_index`) before masked compare.

2. Added example coverage in `example-android/example.cpp`:
   - `findIdaPatternFirst` with wildcard-leading pattern.
   - `findIdaPatternAll` with wildcard-leading pattern.

### Why This Is Correct
- IDA wildcard semantics are preserved for all positions, including the beginning.
- Existing behavior for non-wildcard-leading patterns remains unchanged.
- Runtime complexity remains in the same class with retained memchr acceleration.

### Files Changed
- `KittyMemory/KittyScanner.cpp`
- `example-android/example.cpp`

### Validation
- Verified build integration downstream where wildcard-leading signatures are used.
- Previously failing signatures now resolve correctly.

### Notes
- This is internal logic only; there are no API/ABI changes.
